### PR TITLE
bumpver: ui-web-cli v0.0.40

### DIFF
--- a/.github/workflows/coco-app-web.yml
+++ b/.github/workflows/coco-app-web.yml
@@ -31,8 +31,8 @@ on:
       PUBLISH_CLI_VERSION:
         description: 'Web-CLI Version'
         required: true
-        default: "0.0.39"
-      # new-component: PUBLISH_NEW_VERSION ...
+        default: "0.0.40"
+        # new-component: PUBLISH_NEW_VERSION ...
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Automated release for ui-web-cli.
Version bumped to 0.0.40.