### PR TITLE
bumpver: ui-web-cli v0.0.41

### DIFF
--- a/.github/workflows/coco-app-web.yml
+++ b/.github/workflows/coco-app-web.yml
@@ -32,7 +32,7 @@ on:
       PUBLISH_CLI_VERSION:
         description: 'Web-CLI Version'
         required: true
-        default: "0.0.40"
+        default: "0.0.41"
       PUBLISH_FILTER_VERSION:
         description: 'Filter Version'
         required: true


### PR DESCRIPTION
Automated release for ui-web-cli.
Version bumped to 0.0.41.