### PR TITLE
chore: clean previous docs output before build for main branch

### DIFF
--- a/.github/workflows/easysearch-docs.yml
+++ b/.github/workflows/easysearch-docs.yml
@@ -150,7 +150,7 @@ jobs:
             git pull origin main
             
             # Build Docs for Main Branch (latest)
-            (cd docs && OUTPUT=$(pwd)/../../docs-output VERSION="main" BRANCH="main" make docs-build docs-place-redirect)
+            (cd docs && OUTPUT=$(pwd)/../../docs-output VERSION="main" BRANCH="main" && rm -rif "$(OUTPUT)/$(PRODUCT)/$(VERSION)/*" && make docs-build docs-place-redirect)
 
             # Commit and Push Latest Docs to Main
             cd $GITHUB_WORKSPACE/docs-output


### PR DESCRIPTION
Remove old documentation output before building new docs.