### PR TITLE
chore: update easysearch .versions.json for 2.1.0 (build 2661)

### DIFF
--- a/products/easysearch/publish/.versions.json
+++ b/products/easysearch/publish/.versions.json
@@ -1,4 +1,14 @@
 {
+  "2.1.0": {
+    "platforms": [
+      "linux-amd64",
+      "linux-arm64",
+      "mac-amd64",
+      "mac-arm64",
+      "windows-amd64"
+    ],
+    "build_number": 2661
+  },
   "2.0.2": {
     "platforms": [
       "linux-amd64",


### PR DESCRIPTION
This PR was created by GitHub Actions to update the Easysearch versions metadata.