### PR TITLE
chore: update easysearch snapshot versions

### DIFF
--- a/products/easysearch/publish/.snapshot-versions.json
+++ b/products/easysearch/publish/.snapshot-versions.json
@@ -8,7 +8,7 @@
       "windows-amd64"
     ]
   },
-  "2.2.0-20260324": {
+  "2.2.0-20260325": {
     "platforms": [
       "linux-amd64",
       "linux-arm64",


### PR DESCRIPTION
Automated update of easysearch snapshot versions after build 23503411150