### PR TITLE
bumpver: update easysearch .versions.json for 2.1.2 (build 2690)

### DIFF
--- a/products/easysearch/publish/.versions.json
+++ b/products/easysearch/publish/.versions.json
@@ -1,4 +1,14 @@
 {
+  "2.1.2": {
+    "platforms": [
+      "linux-amd64",
+      "linux-arm64",
+      "mac-amd64",
+      "mac-arm64",
+      "windows-amd64"
+    ],
+    "build_number": 2690
+  },
   "2.1.1": {
     "platforms": [
       "linux-amd64",


### PR DESCRIPTION
Automated update of Easysearch versions metadata for 2.1.2-2690