### PR TITLE
bumpver: update easysearch .versions.json for 2.1.2 (build 2696)

### DIFF
--- a/products/easysearch/publish/.versions.json
+++ b/products/easysearch/publish/.versions.json
@@ -7,7 +7,7 @@
       "mac-arm64",
       "windows-amd64"
     ],
-    "build_number": 2690
+    "build_number": 2696
   },
   "2.1.1": {
     "platforms": [


### PR DESCRIPTION
Automated update of Easysearch versions metadata for 2.1.2-2696