### PR TITLE
bumpver: update easysearch .versions.json for 1.15.6 (build 2740)

### DIFF
--- a/products/easysearch/publish/.versions.json
+++ b/products/easysearch/publish/.versions.json
@@ -67,7 +67,7 @@
       "mac-arm64",
       "windows-amd64"
     ],
-    "build_number": 2468
+    "build_number": 2740
   },
   "1.15.5": {
     "platforms": [


### PR DESCRIPTION
Automated update of Easysearch versions metadata for 1.15.6-2740