### PR TITLE
chore: update easysearch snapshot versions

### DIFF
--- a/products/easysearch/publish/.snapshot-versions.json
+++ b/products/easysearch/publish/.snapshot-versions.json
@@ -8,7 +8,7 @@
       "windows-amd64"
     ]
   },
-  "2.4.0-20260720": {
+  "2.4.0-20260721": {
     "platforms": [
       "linux-amd64",
       "linux-arm64",


### PR DESCRIPTION
Automated update of easysearch snapshot versions after build 29761993737