### PR TITLE
bumpver: update easysearch .versions.json for 2.3.1 (build 2903)

### DIFF
--- a/products/easysearch/publish/.versions.json
+++ b/products/easysearch/publish/.versions.json
@@ -1,4 +1,14 @@
 {
+  "2.3.1": {
+    "platforms": [
+      "linux-amd64",
+      "linux-arm64",
+      "mac-amd64",
+      "mac-arm64",
+      "windows-amd64"
+    ],
+    "build_number": 2903
+  },
   "2.3.0": {
     "platforms": [
       "linux-amd64",


### PR DESCRIPTION
Automated update of Easysearch versions metadata for 2.3.1-2903